### PR TITLE
新規登録の前に確認画面を表示する

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -41,6 +41,11 @@ class TasksController < ApplicationController
     redirect_to tasks_url, notice: "タスク「#{task.name}」を削除しました。", status: :see_other
   end
 
+  def confirm_new
+    @task = current_user.tasks.new(task_params)
+    render :new unless @task.valid?
+  end
+
   private
 
   def task_params

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -18,6 +18,11 @@ class TasksController < ApplicationController
   def create
     @task = current_user.tasks.new(task_params)
 
+    if params[:back].present?
+      render :new
+      return
+    end
+
     if @task.save
       redirect_to @task, notice: "タスク「#{@task.name}」を登録しました。"
     else
@@ -31,7 +36,7 @@ class TasksController < ApplicationController
     if @task.update(task_params)
       redirect_to tasks_url, notice: "タスク「#{@task.name}」を更新しました。"
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 
@@ -43,7 +48,7 @@ class TasksController < ApplicationController
 
   def confirm_new
     @task = current_user.tasks.new(task_params)
-    render :new unless @task.valid?
+    render :new, status: :unprocessable_entity unless @task.valid?
   end
 
   private

--- a/app/views/tasks/confirm_new.html.erb
+++ b/app/views/tasks/confirm_new.html.erb
@@ -1,6 +1,6 @@
 <h1>登録内容の確認</h1>
 
-<%= form_with model: @task do |f| %>
+<%= form_with model: @task, data: { turbo: false } do |f| %>
   <table class="table table-hover">
     <tbody>
       <tr>

--- a/app/views/tasks/confirm_new.html.erb
+++ b/app/views/tasks/confirm_new.html.erb
@@ -1,0 +1,20 @@
+<h1>登録内容の確認</h1>
+
+<%= form_with model: @task do |f| %>
+  <table class="table table-hover">
+    <tbody>
+      <tr>
+        <th><%= Task.human_attribute_name(:name) %></th>
+        <td><%= @task.name %></td>
+        <%= f.hidden_field :name %>
+      </tr>
+      <tr>
+        <th><%= Task.human_attribute_name(:description) %></th>
+        <td><%= @task.description %></td>
+        <%= f.hidden_field :description %>
+      </tr>
+    </tbody>
+  </table>
+  <%= f.submit '戻る', name: 'back', class: 'btn btn-secondary me-3' %>
+  <%= f.submit '登録', class: 'btn btn-primary' %>
+<% end %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -4,4 +4,26 @@
   <%= link_to '一覧', tasks_path, class: 'nav-link' %>
 </div>
 
-<%= render partial: 'form', locals: { task: @task } %>
+<% if @task.errors.present? %>
+  <ul id="error_explanation">
+    <% @task.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<%= form_with model: @task, url: confirm_new_task_path do |f| %>
+  <div class="mb-3">
+    <div class="form-group">
+      <%= f.label :name, class: 'form-label' %>
+      <%= f.text_field :name, class: 'form-control', id: 'task_name' %>
+    </div>
+  </div>
+  <div class="mb-3">
+    <div class="form-group">
+      <%= f.label :description, class: 'form-label' %>
+      <%= f.text_area :description, rows: 5, class: 'form-control', id: 'task_description' %>
+    </div>
+  </div>
+  <%= f.submit '確認', class: 'btn btn-primary' %>
+<% end %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -12,7 +12,7 @@
   </ul>
 <% end %>
 
-<%= form_with model: @task, url: confirm_new_task_path do |f| %>
+<%= form_with model: @task, url: confirm_new_task_path, data: { turbo: false } do |f| %>
   <div class="mb-3">
     <div class="form-group">
       <%= f.label :name, class: 'form-label' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,7 @@ Rails.application.routes.draw do
   end
 
   root to: 'tasks#index'
-  resources :tasks
+  resources :tasks do
+    post :confirm, action: :confirm_new, on: :new
+  end
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -48,13 +48,15 @@ RSpec.describe "Tasks", type: :system do
     before do
       visit new_task_path
       fill_in '名称', with: task_name
-      click_button '登録する'
+      click_button '確認'
     end
 
     context '新規作成画面で名称を入力した時' do
       let(:task_name) { '新規作成のテストを書く' }
 
       it '正常に登録される' do
+        expect(page).to have_content '登録内容の確認'
+        click_button '登録'
         expect(page).to have_selector '.alert-success', text: '新規作成のテストを書く'
       end
     end


### PR DESCRIPTION
# Issue
#19 
# 概要
新規登録画面→登録ボタンで登録の流れから、
新規登録画面→確認ボタンで確認画面→登録ボタンで登録　の流れに変更する。
確認画面では、ユーザーが入力した値を表示して、間違いないかを確認してもらう。
内容に修正が必要な場合は、戻るボタンを押すことで再度入力画面へ遷移する。